### PR TITLE
Remove all listeners for all subscriptions when the client is closed.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -511,6 +511,12 @@ export default class PubSubApiClient {
      * @memberof PubSubApiClient.prototype
      */
     close() {
+        this.#logger.info('Clear subscriptions');
+        this.#subscriptions.forEach((subscription) => {
+            subscription.removeAllListeners();
+        });
+        this.#subscriptions.clear();
+
         this.#logger.info('Closing gRPC stream');
         this.#client.close();
     }


### PR DESCRIPTION
This update ensures that all listeners on all subscriptions are cleared when client.close() is called, and the subscriptions list is cleared as well.

Details:
**Clear Subscriptions and Listeners:**
	•	When client.close() is called, all listeners on all subscriptions are removed to prevent them from continuing to receive events.
	•	The subscriptions list is also cleared to release any references to the subscriptions.
**Reason:**
	•	Previously, even after calling client.close(), the listeners remained active and continued to receive events from the Salesforce gRPC channel.
	•	Since the channel is closed, these events cannot be handled properly and eventually result in errors such as `Failed to load schema with ID .....` because the client is already closed.

This change prevents the aforementioned issues by ensuring that all subscriptions and their listeners are properly cleaned up when the client is closed.