### PR TITLE
Changes to address issue #38

### DIFF
--- a/dist/client.cjs
+++ b/dist/client.cjs
@@ -825,13 +825,13 @@ var PubSubApiClient = class {
         topicName,
         numRequested
       );
-      subscription.on("data", (data) => {
+      subscription.on("data", async (data) => {
         const latestReplayId = decodeReplayId(data.latestReplayId);
         if (data.events) {
           this.#logger.info(
             `Received ${data.events.length} events, latest replay ID: ${latestReplayId}`
           );
-          data.events.forEach(async (event) => {
+          for (const event of data.events) {
             try {
               let schema;
               if (topicName.endsWith("__chn")) {
@@ -884,7 +884,7 @@ var PubSubApiClient = class {
                 eventEmitter.emit("lastevent");
               }
             }
-          });
+          }
         } else {
           this.#logger.debug(
             `Received keepalive message. Latest replay ID: ${latestReplayId}`

--- a/dist/client.js
+++ b/dist/client.js
@@ -792,13 +792,13 @@ var PubSubApiClient = class {
         topicName,
         numRequested
       );
-      subscription.on("data", (data) => {
+      subscription.on("data", async (data) => {
         const latestReplayId = decodeReplayId(data.latestReplayId);
         if (data.events) {
           this.#logger.info(
             `Received ${data.events.length} events, latest replay ID: ${latestReplayId}`
           );
-          data.events.forEach(async (event) => {
+          for (const event of data.events) {
             try {
               let schema;
               if (topicName.endsWith("__chn")) {
@@ -851,7 +851,7 @@ var PubSubApiClient = class {
                 eventEmitter.emit("lastevent");
               }
             }
-          });
+          }
         } else {
           this.#logger.debug(
             `Received keepalive message. Latest replay ID: ${latestReplayId}`

--- a/src/client.js
+++ b/src/client.js
@@ -318,13 +318,13 @@ export default class PubSubApiClient {
                 topicName,
                 numRequested
             );
-            subscription.on('data', (data) => {
+            subscription.on('data', async (data) => {
                 const latestReplayId = decodeReplayId(data.latestReplayId);
                 if (data.events) {
                     this.#logger.info(
                         `Received ${data.events.length} events, latest replay ID: ${latestReplayId}`
                     );
-                    data.events.forEach(async (event) => {
+                    for (const event of data.events) {
                         try {
                             let schema;
                             // Are we subscribing to a custom channel?
@@ -395,7 +395,7 @@ export default class PubSubApiClient {
                                 eventEmitter.emit('lastevent');
                             }
                         }
-                    });
+                    }
                 } else {
                     // If there are no events then, every 270 seconds (or less) the server publishes a keepalive message with
                     // the latestReplayId and pendingNumRequested (the number of events that the client is still waiting for)


### PR DESCRIPTION
Agree with @brodymccrone4 in issue #38, using `async/await` within a `forEach()` loop can lead to unexpected behaviour because `forEach()` is not designed to handle asynchronous operations properly since each iteration loop is non-blocking. This leads to multiple events being handled in parallel, which leads to having the events processed in random order rather than sequential as required.

Although gRPC returns the events sequentially, with the replayId incrementing when the `data` events are received by this library, when they are dispatched inside a `forEach` that order is mixed having the application using this library receive the events in dis-order.