### PR TITLE
feat: support custom gRPC channel options via configuration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -177,7 +177,8 @@ export default class PubSubApiClient {
             // Return pub/sub gRPC client
             this.#client = new sfdcPackage.PubSub(
                 this.#config.pubSubEndpoint,
-                combCreds
+                combCreds,
+                this.#config.grpcChannelOptions ?? {}
             );
             this.#logger.info(
                 `Connected to Pub/Sub API endpoint ${this.#config.pubSubEndpoint}`

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -123,6 +123,7 @@ export const EventSubscriptionAdminState = {
  * @property {string} [instanceUrl] Salesforce instance URL.
  * @property {string} [organizationId] Optional organization ID. If you don't provide one, we'll attempt to parse it from the accessToken.
  * @property {boolean} [rejectUnauthorizedSsl] Optional flag used to accept self-signed SSL certificates for testing purposes when set to `false`. Default is `true` (client rejects self-signed SSL certificates).
+ * @property {Object} [grpcChannelOptions] Optional gRPC channel options passed directly to the gRPC client constructor. Use to configure transport-level settings such as keepalive (e.g. `grpc.keepalive_time_ms`, `grpc.keepalive_timeout_ms`, `grpc.keepalive_permit_without_calls`).
  */
 
 /**


### PR DESCRIPTION
Problem
When subscribing to topics, the underlying gRPC stream can silently stop receiving events without triggering end or error callbacks. This happens when the TCP connection becomes half-open — a common situation in cloud environments where NAT gateways or load balancers silently drop idle connections after a period of inactivity.

Since the Salesforce Pub/Sub API sends application-level keepalive frames only every ~270 seconds, a silent TCP drop can go undetected for several minutes, leaving subscriptions effectively dead with no way to recover.

Solution
gRPC has a built-in transport-level keepalive mechanism based on HTTP/2 PING frames. When configured, the gRPC client periodically sends a PING to the server and expects a response within a deadline. If no response is received, the connection is declared dead and an error event is emitted on the stream — which the consumer can handle to reconnect.

This PR exposes grpcChannelOptions as an optional field in the Configuration object. The value is passed as-is as the third argument to the gRPC client constructor, giving consumers full control over transport-level settings without requiring library changes for each new option.