### PR TITLE
build: upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,16 +25,16 @@ jobs:
         steps:
             # Checkout the source code
             - name: 'Checkout source code'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             # Install Volta to enforce proper node and package manager versions
             - name: 'Install Volta'
-              uses: volta-cli/action@v4
+              uses: volta-cli/action@v5
 
             # Cache node_modules to speed up the process
             - name: 'Restore node_modules cache'
               id: cache-npm
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,16 @@ jobs:
         steps:
             # Checkout the source code
             - name: 'Checkout source code'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             # Install Volta to enforce proper node and package manager versions
             - name: 'Install Volta'
-              uses: volta-cli/action@v4
+              uses: volta-cli/action@v5
 
             # Cache node_modules to speed up the process
             - name: 'Restore node_modules cache'
               id: cache-npm
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6
- `volta-cli/action` v4 → v5
- `actions/cache` v4 → v5

Applied to both `ci.yml` and `ci-pr.yml`.

## Test plan

- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)